### PR TITLE
A little more UI refactor, cleanup, eslint more strict

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,20 @@
         "ecmaVersion": 6,
         "sourceType": "module"
     },
+    "env": {
+      "es6": true,
+      "browser": true,
+      "node": true
+    },
     "extends": "google",
     "rules": {
+      "init-declarations": ["error", "always"],
+      "no-catch-shadow": ["error"],
+      "no-delete-var": ["error"],
+      "no-shadow": ["error", { "builtinGlobals": false, "hoist": "functions", "allow": [] }],
+      "no-shadow-restricted-names": ["error"],
+      "no-undef": ["error", {"typeof": true}],
+      "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
+      "no-use-before-define": ["error", { "functions": true, "classes": true }]
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-minify-webpack-plugin": "^0.3.0",
+    "babel-plugin-transform-imports": "^1.5.0",
     "babel-preset-env": "^1.6.1",
     "clean-webpack-plugin": "^0.1.18",
     "compression-webpack-plugin": "^1.1.10",

--- a/ui-src/assets/index.css
+++ b/ui-src/assets/index.css
@@ -4,7 +4,8 @@ body {
 #nav {
     float: left;
 }
-.ui-datepicker {
+
+#datetime .ui-datepicker {
     width: 100%;
 }
 

--- a/ui-src/index.js
+++ b/ui-src/index.js
@@ -33,6 +33,7 @@
 import NVRApplication from './NVRApplication';
 
 import $ from 'jquery';
+import './favicon.ico';
 
 // On document load, start application
 $(function() {

--- a/ui-src/lib/MoonfireAPI.js
+++ b/ui-src/lib/MoonfireAPI.js
@@ -59,7 +59,7 @@ export default class MoonfireAPI {
     url.hostname = host;
     url.port = port;
     console.log('API: ' + url.origin + url.pathname);
-    this._builder = new URLBuilder(url.origin + url.pathname);
+    this._builder = new URLBuilder(url.origin + url.pathname, relativeUrls);
   }
 
   /**

--- a/ui-src/lib/models/CalendarTSRange.js
+++ b/ui-src/lib/models/CalendarTSRange.js
@@ -31,7 +31,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import Time90kParser from '../support/Time90kParser';
-import {TimeStamp90kFormatter} from '../support/TimeFormatter';
+import TimeStamp90kFormatter from '../support/TimeStamp90kFormatter';
 import Range90k from './Range90k';
 
 /**

--- a/ui-src/lib/models/Range.js
+++ b/ui-src/lib/models/Range.js
@@ -45,7 +45,7 @@ export default class Range {
    */
   constructor(low, high) {
     if (high < low) {
-      console.log('Warning range swap: ' + low + ' - ' + high);
+      console.warn('Warning range swap: ' + low + ' - ' + high);
       [low, high] = [high, low];
     }
     this.low = low;
@@ -65,7 +65,7 @@ export default class Range {
    * Determine if value is inside the range.
    *
    * @param  {Number}  value Value to test
-   * @return {Boolean}
+   * @return {Boolean} 
    */
   isInRange(value) {
     return value >= this.low && value <= this.high;

--- a/ui-src/lib/support/TimeFormatter.js
+++ b/ui-src/lib/support/TimeFormatter.js
@@ -32,7 +32,7 @@
 
 import moment from 'moment-timezone';
 
-export const internalTimeFormat = 'YYYY-MM-DDTHH:mm:ss:FFFFFZ';
+
 export const defaultTimeFormat = 'YYYY-MM-DD HH:mm:ss';
 
 /**
@@ -116,51 +116,26 @@ export default class TimeFormatter {
     }
     return moment.tz(ms, this._tz).format(format);
   }
-}
-
-/**
- * Specialized class similar to TimeFormatter but forcing a specific time format
- * for internal usage purposes.
- */
-export class TimeStamp90kFormatter {
-  /**
-   * Construct from just a timezone specification.
-   *
-   * @param  {String} tz Timezone
-   */
-  constructor(tz) {
-    this._formatter = new TimeFormatter(internalTimeFormat, tz);
-  }
 
   /**
-   * Format a timestamp in 90k units using internal format.
+   * Format timestamp expressed in mill-seconds.
    *
-   * @param {Number} ts90k timestamp in 90,000ths of a second resolution
+   * @param  {Number} ms     A timestamp in ms to be formatted
    * @return {String}        Formatted timestamp
    */
-  formatTimeStamp90k(ts90k) {
-    return this._formatter.formatTimeStamp90k(ts90k);
+  formatTimeStampMs(ms) {
+    // Convert to 90k value first
+    return this.formatTimeStamp90k(ms * 90);
   }
 
   /**
-   * Given two timestamp return formatted versions of both, where the second
-   * one may have been shortened if it falls on the same date as the first one.
+   * Format timestamp expressed in mill-seconds.
    *
-   * @param  {Number} ts1 First timestamp in 90k units
-   * @param  {Number} ts2 Secodn timestamp in 90k units
-   * @return {Array}     Array with two elements: [ ts1Formatted, ts2Formatted ]
+   * @param  {Number} s      A timestamp in s to be formatted
+   * @return {String}        Formatted timestamp
    */
-  formatSameDayShortened(ts1, ts2) {
-    let ts1Formatted = this.formatTimeStamp90k(ts1);
-    let ts2Formatted = this.formatTimeStamp90k(ts2);
-    let timePos = this._formatter.formatStr.indexOf('T');
-    if (timePos != -1) {
-      const datePortion = ts1Formatted.substr(0, timePos);
-      ts1Formatted = datePortion + ' ' + ts1Formatted.substr(timePos + 1);
-      if (ts2Formatted.startsWith(datePortion)) {
-        ts2Formatted = ts2Formatted.substr(timePos + 1);
-      }
-    }
-    return [ts1Formatted, ts2Formatted];
+  formatTimeStampSec(s) {
+    // Convert to 90k value first
+    return this.formatTimeStamp90k(s * 90000);
   }
 }

--- a/ui-src/lib/support/TimeFormatter.js
+++ b/ui-src/lib/support/TimeFormatter.js
@@ -116,26 +116,4 @@ export default class TimeFormatter {
     }
     return moment.tz(ms, this._tz).format(format);
   }
-
-  /**
-   * Format timestamp expressed in mill-seconds.
-   *
-   * @param  {Number} ms     A timestamp in ms to be formatted
-   * @return {String}        Formatted timestamp
-   */
-  formatTimeStampMs(ms) {
-    // Convert to 90k value first
-    return this.formatTimeStamp90k(ms * 90);
-  }
-
-  /**
-   * Format timestamp expressed in mill-seconds.
-   *
-   * @param  {Number} s      A timestamp in s to be formatted
-   * @return {String}        Formatted timestamp
-   */
-  formatTimeStampSec(s) {
-    // Convert to 90k value first
-    return this.formatTimeStamp90k(s * 90000);
-  }
 }

--- a/ui-src/lib/views/CalendarView.js
+++ b/ui-src/lib/views/CalendarView.js
@@ -31,20 +31,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import $ from 'jquery';
-import 'jquery-ui/themes/base/button.css';
-import 'jquery-ui/themes/base/core.css';
-import 'jquery-ui/themes/base/datepicker.css';
-import 'jquery-ui/themes/base/dialog.css';
-import 'jquery-ui/themes/base/resizable.css';
-import 'jquery-ui/themes/base/theme.css';
-import 'jquery-ui/themes/base/tooltip.css';
-import 'jquery-ui/ui/widgets/datepicker';
-import 'jquery-ui/ui/widgets/dialog';
-import 'jquery-ui/ui/widgets/tooltip';
 
 import DatePickerView from './DatePickerView';
 import CalendarTSRange from '../models/CalendarTSRange';
-import {TimeStamp90kFormatter} from '../support/TimeFormatter';
+import TimeStamp90kFormatter from '../support/TimeStamp90kFormatter';
 import Time90kParser from '../support/Time90kParser';
 
 /**
@@ -177,10 +167,11 @@ export default class CalendarView {
 
     if (this._sameDay) {
       fromPickerView.option({
-        dateFormat: $.datepicker.ISO_8601,
+        dateFormat: DatePickerView.datepicker.ISO_8601,
         minDate: minDateStr,
         maxDate: maxDateStr,
-        onSelect: (dateStr, picker) => this._updateRangeDates(dateStr, dateStr),
+        onSelect: (dateStr /* , picker */) =>
+          this._updateRangeDates(dateStr, dateStr),
         beforeShowDay: beforeShowDay,
         disabled: false,
       });
@@ -188,21 +179,21 @@ export default class CalendarView {
       toPickerView.activate(); // Default state, but alive
     } else {
       fromPickerView.option({
-        dateFormat: $.datepicker.ISO_8601,
+        dateFormat: DatePickerView.datepicker.ISO_8601,
         minDate: minDateStr,
-        onSelect: (dateStr, picker) => {
-          toPickerView.option('minDate', this.fromDateISO);
+        onSelect: (dateStr /* , picker */) => {
+          toPickerView.minDate = this.fromDateISO;
           this._updateRangeDates(dateStr, this.toDateISO);
         },
         beforeShowDay: beforeShowDay,
         disabled: false,
       });
       toPickerView.option({
-        dateFormat: $.datepicker.ISO_8601,
+        dateFormat: DatePickerView.datepicker.ISO_8601,
         minDate: fromPickerView.dateISO,
         maxDate: maxDateStr,
-        onSelect: (dateStr, picker) => {
-          fromPickerView.option('maxDate', this.toDateISO);
+        onSelect: (dateStr /* , picker */) => {
+          fromPickerView.maxDate = this.toDateISO;
           this._updateRangeDates(this.fromDateISO, dateStr);
         },
         beforeShowDay: beforeShowDay,
@@ -228,7 +219,7 @@ export default class CalendarView {
    * The change requires updating the selected range and then informing
    * any listeners that the range has changed (so they can update data).
    *
-   * @param  {Object}  event Time Event on DOM that triggered calling this
+   * @param  {event}  event       DOM event that triggered us
    * @param  {Boolean} isEnd      True if this is for end time
    */
   _pickerTimeChanged(event, isEnd) {
@@ -239,7 +230,7 @@ export default class CalendarView {
       ? selectedRange.setEndTime(newTimeStr)
       : selectedRange.setStartTime(newTimeStr);
     if (parsedTS === null) {
-      console.log('bad time change');
+      console.warn('bad time change');
       $(pickerElement).addClass('ui-state-error');
       return;
     }

--- a/ui-src/lib/views/CameraView.js
+++ b/ui-src/lib/views/CameraView.js
@@ -83,7 +83,7 @@ export default class CameraView {
     this._enabled = enabled;
     this.recordingsView.show = enabled;
     console.log(
-      'Camera ',
+      'Camera %s %s',
       this.camera.shortName,
       this.enabled ? 'enabled' : 'disabled'
     );

--- a/ui-src/lib/views/DatePickerView.js
+++ b/ui-src/lib/views/DatePickerView.js
@@ -32,10 +32,27 @@
 
 import $ from 'jquery';
 
+import 'jquery-ui/themes/base/core.css';
+import 'jquery-ui/themes/base/datepicker.css';
+import 'jquery-ui/themes/base/theme.css';
+import 'jquery-ui/ui/widgets/datepicker';
+
 /**
  * Class to encapsulate datepicker UI widget from jQuery.
  */
 export default class DatePickerView {
+  /**
+   * Get the singleton datepicker instance.
+   *
+   * This is useful for accessing implementation constants, such as
+   * date formats etc.
+   *
+   * @return {jQuery.datepicker} JQuery datepicker instance
+   */
+  static get datepicker() {
+    return $.datepicker;
+  }
+
   /**
    * Construct wapper an attach to a specified parent DOM node.
    *
@@ -85,11 +102,11 @@ export default class DatePickerView {
    *
    * @return {Any} Function result
    */
-  _apply() {
+  _apply(...args) {
     if (!this._alive) {
-      console.log('WARN: datepicker not constructed yet [' + this.domId + ']');
+      console.warn('datepicker not constructed yet [%s]', this.domId);
     }
-    return this._pickerElement.datepicker(...arguments);
+    return this._pickerElement.datepicker(...args);
   }
 
   /**

--- a/ui-src/lib/views/RecordingsView.js
+++ b/ui-src/lib/views/RecordingsView.js
@@ -267,8 +267,8 @@ export default class RecordingsView {
     $('tr.r', tbody).remove();
     this._recordings.forEach((r) => {
       let row = $('<tr class="r" />');
-      row.append(_columnOrder.map((k) => $('<td/>')));
-      row.on('click', (e) => {
+      row.append(_columnOrder.map(() => $('<td/>')));
+      row.on('click', () => {
         console.log('Video clicked');
         if (this._clickHandler !== null) {
           console.log('Video clicked handler call');

--- a/ui-src/lib/views/VideoDialogView.js
+++ b/ui-src/lib/views/VideoDialogView.js
@@ -1,0 +1,99 @@
+// vim: set et sw=2 ts=2:
+//
+// This file is part of Moonfire NVR, a security camera digital video recorder.
+// Copyright (C) 2018 Dolf Starreveld <dolf@starreveld.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// In addition, as a special exception, the copyright holders give
+// permission to link the code of portions of this program with the
+// OpenSSL library under certain conditions as described in each
+// individual source file, and distribute linked combinations including
+// the two.
+//
+// You must obey the GNU General Public License in all respects for all
+// of the code used other than OpenSSL. If you modify file(s) with this
+// exception, you may extend this exception to your version of the
+// file(s), but you are not obligated to do so. If you do not wish to do
+// so, delete this exception statement from your version. If you delete
+// this exception statement from all source files in the program, then
+// also delete it here.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import $ from 'jquery';
+
+import 'jquery-ui/themes/base/core.css';
+import 'jquery-ui/themes/base/dialog.css';
+import 'jquery-ui/themes/base/theme.css';
+// This not needed for pure dialog, but we want it resizable
+import 'jquery-ui/themes/base/resizable.css';
+
+// Get dialog ui widget
+import 'jquery-ui/ui/widgets/dialog';
+
+/**
+ * Class to implement a simple jQuery dialog based video player.
+ */
+export default class VideoDialogView {
+  /**
+   * Construct the player.
+   *
+   * This does not attach the player to the DOM anywhere! In fact, construction
+   * of the necessary video element is delayed until an attach is requested.
+   * Since the close of the video removes all traces of it in the DOM, this
+   * apprach allows repeated use by calling attach again!
+   */
+  constructor() {}
+
+  /**
+   * Attach the player to the specified DOM element.
+   *
+   * @param {Node} domElement DOM element to attach to
+   * @return {VideoDialogView} Returns "this" for chaining.
+   */
+  attach(domElement) {
+    this._videoElement = $('<video controls preload="auto" autoplay="true" />');
+    this._dialogElement = $('<div class="playdialog" />').append(
+      this._videoElement
+    );
+    $(domElement).append(this._dialogElement);
+    return this;
+  }
+
+  /**
+   * Show the player, and start playing the given url.
+   *
+   * @param  {String} title Title of the video player
+   * @param  {Number} width Width of the player
+   * @param  {String} url   URL for source media
+   * @return {VideoDialogView}       Returns "this" for chaining.
+   */
+  play(title, width, url) {
+    this._dialogElement.dialog({
+      title: title,
+      width: width,
+      close: () => {
+        const videoDOMElement = this._videoElement[0];
+        videoDOMElement.pause();
+        videoDOMElement.src = ''; // Remove current source to stop loading
+        this._videoElement = null;
+        this._dialogElement.remove();
+        this._dialogElement = null;
+      },
+    });
+    // Now that dialog is up, set the src so video starts
+    console.log('Video url: ' + url);
+    this._videoElement.attr('src', url);
+    return this;
+  }
+}

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -48,32 +48,41 @@ module.exports = (env, args) => {
       publicPath: '/',
     },
     module: {
-      rules: [{
-        test: /\.js$/,
-        loader: 'babel-loader',
-        query: {
-          'presets': ['env'],
+      rules: [
+        {
+          test: /\.js$/,
+          loader: 'babel-loader',
+          query: {
+            presets: ['env', {modules: false}],
+          },
+          exclude: /(node_modules|bower_components)/,
+          include: ['./ui-src'],
         },
-        exclude: /(node_modules|bower_components)/,
-        include: ['./ui-src'],
-      }, {
-        test: /\.png$/,
-        use: ['file-loader'],
-      }, {
-        test: /\.ico$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]'
-            }
-          }
-        ]
-      }, {
-        // Load css and then in-line in head
-        test: /\.css$/,
-        loader: 'style-loader!css-loader',
-      }],
+        {
+          test: /\.png$/,
+          use: ['file-loader'],
+        },
+        {
+          test: /\.ico$/,
+          use: [
+            {
+              loader: 'file-loader',
+              options: {
+                name: '[name].[ext]',
+              },
+            },
+          ],
+        },
+        {
+          test: /\.png$/,
+          use: ['file-loader'],
+        },
+        {
+          // Load css and then in-line in head
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+      ],
     },
     plugins: [
       new webpack.DefinePlugin({
@@ -83,14 +92,20 @@ module.exports = (env, args) => {
       new HtmlWebpackPlugin({
         title: nvrSettings.app_title,
         filename: 'index.html',
-        template: path.join(nvrSettings._paths.app_src_dir, 'assets', 'index.html'),
+        template: path.join(
+          nvrSettings._paths.app_src_dir,
+          'assets',
+          'index.html'
+        ),
       }),
       new webpack.NormalModuleReplacementPlugin(
         /node_modules\/moment\/moment\.js$/,
-        './min/moment.min.js'),
+        './min/moment.min.js'
+      ),
       new webpack.NormalModuleReplacementPlugin(
         /node_modules\/moment-timezone\/index\.js$/,
-        './builds/moment-timezone-with-data-2012-2022.min.js'),
+        './builds/moment-timezone-with-data-2012-2022.min.js'
+      ),
     ],
   };
 };

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -44,6 +44,7 @@ module.exports = (env, args) => {
     },
     devtool: 'inline-source-map',
     optimization: {
+      minimize: false,
       namedChunks: true,
     },
     devServer: {
@@ -54,11 +55,11 @@ module.exports = (env, args) => {
       hot: true,
       clientLogLevel: 'info',
       proxy: {
-        '/api': `http://${nvrSettings.moonfire.server}:${nvrSettings.moonfire.port}`,
+        '/api': `http://${nvrSettings.moonfire.server}:${
+          nvrSettings.moonfire.port
+        }`,
       },
     },
-    plugins: [
-      new webpack.HotModuleReplacementPlugin(),
-    ],
+    plugins: [new webpack.HotModuleReplacementPlugin()],
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,6 +865,17 @@ babel-plugin-transform-flow-strip-types@^6.8.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-imports@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.5.0.tgz#3105082ab489b1cee162e42d2ffe7b8f7c685f2e"
+  dependencies:
+    babel-types "^6.6.0"
+    is-valid-path "^0.1.1"
+    lodash.camelcase "^4.3.0"
+    lodash.findkey "^4.6.0"
+    lodash.kebabcase "^4.1.1"
+    lodash.snakecase "^4.1.1"
+
 babel-plugin-transform-inline-consecutive-adds@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz#f07d93689c0002ed2b2b62969bdd99f734e03f57"
@@ -1095,7 +1106,7 @@ babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0, babel-types@^6.6.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -3625,6 +3636,12 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-invalid-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-0.1.0.tgz#307a855b3cf1a938b44ea70d2c61106053714f34"
+  dependencies:
+    is-glob "^2.0.0"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3736,6 +3753,12 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-valid-path@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-valid-path/-/is-valid-path-0.1.1.tgz#110f9ff74c37f663e1ec7915eb451f2db93ac9df"
+  dependencies:
+    is-invalid-path "^0.1.0"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -4043,13 +4066,25 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.findkey@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.findkey/-/lodash.findkey-4.6.0.tgz#83058e903b51cbb759d09ccf546dea3ea39c4718"
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
 lodash.some@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
* Split out imports for jQuery components and put them where needed.
* No longer do all of it in application module.
* Prepares better for code splitting.
* Split out video player dialog
* Simplifies jquery-ui dependencies for code splitting
* Simplifies code
* Configure to generate more, but smaller bundles.
* Setup some more strict eslint settings
* Fix css to import rather than require
* Change settings to correctly support tree shaking in production build

Signed-off-by: Dolf Starreveld <dolf@starreveld.com>