### PR TITLE
Do not check for video codec by checking SDP video parameters

### DIFF
--- a/server/src/stream.rs
+++ b/server/src/stream.rs
@@ -411,9 +411,18 @@ impl RetinaOpener {
             .streams()
             .iter()
             .enumerate()
-            .find_map(|(i, s)| match s.parameters() {
-                Some(retina::codec::Parameters::Video(v)) => Some((i, Box::new(v.clone()))),
-                _ => None,
+            .find_map(|(i, s)| {
+                if s.media == "video" && s.encoding_name == "h264" {
+                    Some((
+                        i,
+                        s.parameters().and_then(|p| match p {
+                            retina::codec::Parameters::Video(v) => Some(Box::new(v.clone())),
+                            _ => None,
+                        }),
+                    ))
+                } else {
+                    None
+                }
             })
             .ok_or_else(|| format_err!("couldn't find H.264 video stream"))?;
         session.setup(video_i).await?;
@@ -427,7 +436,7 @@ impl RetinaOpener {
                 Some(Err(e)) => return Err(e.into()),
                 Some(Ok(CodecItem::VideoFrame(mut v))) => {
                     if let Some(v) = v.new_parameters.take() {
-                        video_params = v;
+                        video_params = Some(v);
                     }
                     if v.is_random_access_point {
                         break v;
@@ -436,7 +445,11 @@ impl RetinaOpener {
                 Some(Ok(_)) => {}
             }
         };
-        Ok((session, video_params, first_frame))
+        Ok((
+            session,
+            video_params.ok_or_else(|| format_err!("couldn't find H.264 parameters"))?,
+            first_frame,
+        ))
     }
 }
 


### PR DESCRIPTION
Since retina now supports in-band parameters, we should only check the media type for this.

---

Basically https://github.com/scottlamb/retina/issues/43#issuecomment-983223883 but here ;)

Together with https://github.com/scottlamb/retina/pull/50 this makes the Dafang with [CFW](https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks) work. (Same CFW on the Xiaofang did not have the issue, the difference in stuff returned by the hardware encoders causes this difference.)