### PR TITLE
fix build on nightly rust

### DIFF
--- a/server/base/time.rs
+++ b/server/base/time.rs
@@ -23,7 +23,7 @@ pub const TIME_UNITS_PER_SEC: i64 = 90_000;
 pub struct Time(pub i64);
 
 /// Returns a parser for a `len`-digit non-negative number which fits into an i32.
-fn fixed_len_num<'a>(len: usize) -> impl FnMut(&'a str) -> IResult<&'a str, i32> {
+fn fixed_len_num<'a>(len: usize) -> impl FnMut(&'a str) -> IResult<'a, &'a str, i32> {
     map_res(
         take_while_m_n(len, len, |c: char| c.is_ascii_digit()),
         |input: &str| input.parse::<i32>(),


### PR DESCRIPTION
I was getting this:

```
error[E0106]: missing lifetime specifier
  --> base/time.rs:26:68
   |
26 | fn fixed_len_num<'a>(len: usize) -> impl FnMut(&'a str) -> IResult<&'a str, i32> {
   |                                                                    ^ expected named lifetime parameter
   |
   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
help: consider using the `'a` lifetime
```

with rustc 1.62.0-nightly (a707f4010 2022-04-29).