### PR TITLE
Fix chown in build instructions.

### DIFF
--- a/guide/build.md
+++ b/guide/build.md
@@ -244,7 +244,7 @@ the binaries in the working copy will run via just `nvr`:
 $ sudo mkdir /usr/local/lib/moonfire-nvr
 $ sudo ln -s `pwd`/ui/build /usr/local/lib/moonfire-nvr/ui
 $ sudo mkdir /var/lib/moonfire-nvr
-$ sudo chown $USER:$USER /var/lib/moonfire-nvr
+$ sudo chown $USER: /var/lib/moonfire-nvr
 $ ln -s `pwd`/server/target/release/moonfire-nvr $HOME/bin/moonfire-nvr 
 $ ln -s moonfire-nvr $HOME/bin/nvr
 $ nvr init


### PR DESCRIPTION
The build instructions currently fail if the user doesn't have a group matching their user name (not a universally adopted convention).  Update the command to use the following functionality of the `chown` command:

"If a colon but no group name follows the user name, that user is made the owner of the files and the group of the files is changed to that user's login group."