### PR TITLE
Add "Copy config" option to "Add camera" dialog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Rust ${{ matrix.rust }}
     strategy:
       matrix:
-        rust: [ "stable", "1.64", "nightly" ]
+        rust: [ "stable", "1.65", "nightly" ]
         include:
           - rust: nightly
             extra_args: "--features nightly --benches"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ even on minor releases, e.g. `0.7.5` -> `0.7.6`.
 
 ## unreleased
 
-*   bump minimum Rust version to 1.64.
+*   bump minimum Rust version to 1.65.
 *   expect camelCase in `moonfire-nvr.toml` file, for consistency with the JSON
     API. You'll need to adjust your config file when upgrading.
 *   use Retina 0.4.4.

--- a/guide/build.md
+++ b/guide/build.md
@@ -208,7 +208,7 @@ following command:
 $ brew install node
 ```
 
-Next, you need Rust 1.64+ and Cargo. The easiest way to install them is by
+Next, you need Rust 1.65+ and Cargo. The easiest way to install them is by
 following the instructions at [rustup.rs](https://www.rustup.rs/). Avoid
 your Linux distribution's Rust packages, which tend to be too old.
 (At least on Debian-based systems; Arch and Gentoo might be okay.)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Scott Lamb <slamb@slamb.org>"]
 edition = "2021"
 resolver = "2"
 license-file = "../LICENSE.txt"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [features]
 

--- a/server/db/writer.rs
+++ b/server/db/writer.rs
@@ -198,7 +198,7 @@ pub struct NewLimit {
 /// This is expected to be performed from `moonfire-nvr config` when no syncer is running.
 /// It potentially flushes the database twice (before and after the actual deletion).
 pub fn lower_retention(
-    db: Arc<db::Database>,
+    db: &Arc<db::Database>,
     dir_id: i32,
     limits: &[NewLimit],
 ) -> Result<(), Error> {

--- a/server/src/cmds/config/dirs.rs
+++ b/server/src/cmds/config/dirs.rs
@@ -137,7 +137,7 @@ fn actually_delete(model: &RefCell<Model>, siv: &mut Cursive) {
         let mut l = model.db.lock();
         l.open_sample_file_dirs(&[model.dir_id]).unwrap(); // TODO: don't unwrap.
     }
-    if let Err(e) = writer::lower_retention(model.db.clone(), model.dir_id, &new_limits[..]) {
+    if let Err(e) = writer::lower_retention(&model.db, model.dir_id, &new_limits[..]) {
         siv.add_layer(
             views::Dialog::text(format!("Unable to delete excess video: {e}"))
                 .title("Error")

--- a/server/src/cmds/config/mod.rs
+++ b/server/src/cmds/config/mod.rs
@@ -50,9 +50,9 @@ pub fn run(args: Args) -> Result<i32, Error> {
         views::Dialog::around(
             views::SelectView::<fn(&Arc<db::Database>, &mut Cursive)>::new()
                 .on_submit(move |siv, item| item(&db, siv))
-                .item("Cameras and streams".to_string(), cameras::top_dialog)
-                .item("Directories and retention".to_string(), dirs::top_dialog)
-                .item("Users".to_string(), users::top_dialog),
+                .item("Cameras and streams", cameras::top_dialog)
+                .item("Directories and retention", dirs::top_dialog)
+                .item("Users", users::top_dialog),
         )
         .button("Quit", |siv| siv.quit())
         .title("Main menu"),

--- a/server/src/cmds/config/users.rs
+++ b/server/src/cmds/config/users.rs
@@ -127,9 +127,7 @@ fn edit_user_dialog(db: &Arc<db::Database>, siv: &mut Cursive, item: Option<i32>
         let l = db.lock();
         let u = item.map(|id| l.users_by_id().get(&id).unwrap());
         username = u.map(|u| u.username.clone()).unwrap_or_default();
-        id_str = item
-            .map(|id| id.to_string())
-            .unwrap_or_else(|| "<new>".to_string());
+        id_str = item.map_or_else(|| "<new>".to_string(), |id| id.to_string());
         has_password = u.map(|u| u.has_password()).unwrap_or(false);
         permissions = u.map(|u| u.permissions.clone()).unwrap_or_default();
     }
@@ -138,7 +136,7 @@ fn edit_user_dialog(db: &Arc<db::Database>, siv: &mut Cursive, item: Option<i32>
         .child(
             "username",
             views::EditView::new()
-                .content(username.clone())
+                .content(&username)
                 .with_name("username"),
         );
     let mut layout = views::LinearLayout::vertical()


### PR DESCRIPTION
When adding cameras in the config TUI, very often multiple cameras need very similar values in their configurations. This pull request adds a button to the "Add camera" dialog to fill in the fields from an existing camera.

![image](https://github.com/scottlamb/moonfire-nvr/assets/5225017/a0246653-4a29-428b-90e5-565d8c86ec93)

This pull request is two commits, where the first is a bunch of tiny code improvements around the TUI I found while working, with no functional changes, and the second is the feature itself.
I'm happy to implement any requested changes in how this feature could work. This just seemed to me like the nicest way to improve this use case. I don't personally use moonfire-nvr, but I'm working on it on request of friend who is.