### PR TITLE
Fix deleting a camera with no video duplicating dialog

### DIFF
--- a/server/src/cmds/config/cameras.rs
+++ b/server/src/cmds/config/cameras.rs
@@ -343,7 +343,10 @@ fn press_delete(siv: &mut Cursive, db: &Arc<db::Database>, id: i32, name: String
         ))
         .button("Delete", {
             let db = db.clone();
-            move |s| actually_delete(s, &db, id)
+            move |s| {
+                s.pop_layer();
+                actually_delete(s, &db, id);
+            }
         })
     }
     .title("Delete camera")


### PR DESCRIPTION
If one deletes a camera without any saved video, not enough dialog layers are popped, and it draws a new camera list dialog on top of the old one instead of replacing it like it should. This change fixes that bug.