### PR TITLE
Make cameras list in TUI scrollable on overflow

### DIFF
--- a/server/src/cmds/config/cameras.rs
+++ b/server/src/cmds/config/cameras.rs
@@ -670,7 +670,8 @@ pub fn top_dialog(db: &Arc<db::Database>, siv: &mut Cursive) {
                         .iter()
                         .map(|(&id, camera)| (format!("{}: {}", id, camera.short_name), Some(id))),
                 )
-                .full_width(),
+                .full_width()
+                .scrollable(),
         )
         .dismiss_button("Done")
         .title("Edit cameras"),


### PR DESCRIPTION
If there are more cameras than the TUI terminal height allows, it would cut off the list and not show you the last ones. This change makes it scroll on overflow instead.

![image](https://github.com/scottlamb/moonfire-nvr/assets/5225017/418d7eb4-0065-431b-a023-d65d6fb97d1e)
↓
![image](https://github.com/scottlamb/moonfire-nvr/assets/5225017/44693aa9-85c0-4d5c-83f7-f0199f62eec9)
