### PR TITLE
Add tab completion to Add sample file dir dialog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Scott Lamb <slamb@slamb.org>
 Dolf Starreveld <dolf@starreveld.com>
+Sky1e <me@skye-c.at>

--- a/server/src/cmds/config/dirs.rs
+++ b/server/src/cmds/config/dirs.rs
@@ -219,7 +219,7 @@ pub fn top_dialog(db: &Arc<db::Database>, siv: &mut Cursive) {
     );
 }
 
-fn tab_completer(content: &str) -> Box<[String]> {
+fn tab_completer(content: &str) -> Vec<String> {
     let (parent, final_segment) = content.split_at(content.rfind('/').map(|i| i + 1).unwrap_or(0));
     Path::new(parent)
         .read_dir()
@@ -236,7 +236,7 @@ fn tab_completer(content: &str) -> Box<[String]> {
                 None
             }
         })
-        .collect::<Box<[String]>>()
+        .collect::<Vec<_>>()
         .with(|completions| {
             // Sort ignoring initial dot
             completions.sort_by(|a, b| {

--- a/server/src/cmds/config/mod.rs
+++ b/server/src/cmds/config/mod.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 mod cameras;
 mod dirs;
+mod tab_complete;
 mod users;
 
 /// Interactively edits configuration.

--- a/server/src/cmds/config/tab_complete.rs
+++ b/server/src/cmds/config/tab_complete.rs
@@ -1,0 +1,141 @@
+use std::{cell::RefCell, rc::Rc};
+
+use cursive::{
+    direction::Direction,
+    event::{Event, EventResult, Key},
+    menu,
+    view::CannotFocus,
+    views::{self, EditView, MenuPopup},
+    Printer, Rect, Vec2, View,
+};
+
+type TabCompleteFn = Rc<dyn Fn(&str) -> Box<[String]>>;
+
+pub struct TabCompleteEditView {
+    edit_view: Rc<RefCell<EditView>>,
+    tab_completer: Option<TabCompleteFn>,
+}
+
+impl TabCompleteEditView {
+    pub fn new(edit_view: EditView) -> Self {
+        Self {
+            edit_view: Rc::new(RefCell::new(edit_view)),
+            tab_completer: None,
+        }
+    }
+
+    pub fn on_tab_complete(mut self, handler: impl Fn(&str) -> Box<[String]> + 'static) -> Self {
+        self.tab_completer = Some(Rc::new(handler));
+        self
+    }
+}
+
+impl View for TabCompleteEditView {
+    fn draw(&self, printer: &Printer) {
+        self.edit_view.borrow().draw(printer)
+    }
+
+    fn layout(&mut self, size: Vec2) {
+        self.edit_view.borrow_mut().layout(size)
+    }
+
+    fn take_focus(&mut self, source: Direction) -> Result<EventResult, CannotFocus> {
+        self.edit_view.borrow_mut().take_focus(source)
+    }
+
+    fn on_event(&mut self, event: Event) -> EventResult {
+        if !self.edit_view.borrow().is_enabled() {
+            return EventResult::Ignored;
+        }
+
+        if let Event::Key(Key::Tab) = event {
+            if let Some(tab_completer) = self.tab_completer.clone() {
+                tab_complete(self.edit_view.clone(), tab_completer, true)
+            } else {
+                EventResult::consumed()
+            }
+        } else {
+            self.edit_view.borrow_mut().on_event(event)
+        }
+    }
+
+    fn important_area(&self, view_size: Vec2) -> Rect {
+        self.edit_view.borrow().important_area(view_size)
+    }
+}
+
+fn tab_complete(
+    edit_view: Rc<RefCell<EditView>>,
+    tab_completer: TabCompleteFn,
+    autofill_one: bool,
+) -> EventResult {
+    let completions = tab_completer(edit_view.borrow().get_content().as_str());
+    EventResult::with_cb_once(move |siv| match *completions {
+        [] => {}
+        [ref completion] if autofill_one => edit_view.borrow_mut().set_content(completion)(siv),
+        [..] => {
+            siv.add_layer(TabCompletePopup {
+                popup: views::MenuPopup::new(Rc::new({
+                    let mut tree = menu::Tree::new();
+                    for completion in Vec::from(completions) {
+                        let edit_view = edit_view.clone();
+                        tree.add_leaf(&completion.clone(), move |siv| {
+                            edit_view.borrow_mut().set_content(&completion)(siv)
+                        })
+                    }
+                    tree
+                })),
+                edit_view,
+                tab_completer,
+            });
+        }
+    })
+}
+
+struct TabCompletePopup {
+    edit_view: Rc<RefCell<EditView>>,
+    popup: MenuPopup,
+    tab_completer: TabCompleteFn,
+}
+impl TabCompletePopup {
+    fn forward_event_and_refresh(&self, event: Event) -> EventResult {
+        let edit_view = self.edit_view.clone();
+        let tab_completer = self.tab_completer.clone();
+        EventResult::with_cb_once(move |s| {
+            s.pop_layer();
+            edit_view.borrow_mut().on_event(event).process(s);
+            tab_complete(edit_view, tab_completer, false).process(s);
+        })
+    }
+}
+
+impl View for TabCompletePopup {
+    fn draw(&self, printer: &Printer) {
+        self.popup.draw(printer)
+    }
+
+    fn required_size(&mut self, req: Vec2) -> Vec2 {
+        self.popup.required_size(req)
+    }
+
+    fn on_event(&mut self, event: Event) -> EventResult {
+        match self.popup.on_event(event.clone()) {
+            EventResult::Ignored => match event {
+                e @ (Event::Char(_) | Event::Key(Key::Backspace)) => {
+                    self.forward_event_and_refresh(e)
+                }
+                Event::Key(Key::Tab) => self.popup.on_event(Event::Key(Key::Enter)),
+                _ => EventResult::Ignored,
+            },
+            other => other,
+        }
+    }
+
+    fn layout(&mut self, size: Vec2) {
+        self.popup.layout(size)
+    }
+
+    fn important_area(&self, size: Vec2) -> Rect {
+        self.popup.important_area(size)
+    }
+}

--- a/server/src/cmds/config/tab_complete.rs
+++ b/server/src/cmds/config/tab_complete.rs
@@ -1,3 +1,7 @@
+// This file is part of Moonfire NVR, a security camera network video recorder.
+// Copyright (C) 2020 The Moonfire NVR Authors; see AUTHORS and LICENSE.txt.
+// SPDX-License-Identifier: GPL-v3.0-or-later WITH GPL-3.0-linking-exception.
+
 use std::{cell::RefCell, rc::Rc};
 
 use cursive::{

--- a/server/src/cmds/config/tab_complete.rs
+++ b/server/src/cmds/config/tab_complete.rs
@@ -79,9 +79,9 @@ fn tab_complete(
                     menu::Tree::new().with(|tree| {
                         for completion in completions {
                             let edit_view = edit_view.clone();
-                            tree.add_leaf(&completion.clone(), move |siv| 
+                            tree.add_leaf(&completion.clone(), move |siv| {
                                 edit_view.borrow_mut().set_content(&completion)(siv)
-                            )
+                            })
                         }
                     })
                 })),


### PR DESCRIPTION
This ended up significantly more involved to implement than I expected when I started.

![image](https://github.com/scottlamb/moonfire-nvr/assets/5225017/15001c03-e2f2-4888-b151-c05c9e425440)

On the Add sample file directory screen, implement path tab completion. I ended up having to create custom views for the behavior, which wrap existing views, but change their behavior with a couple events.