### PR TITLE
upgrade `bpaf` to nearly-0.9.1

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -66,17 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "bitstream-io"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,23 +141,22 @@ dependencies = [
 
 [[package]]
 name = "bpaf"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f4c9de9c67618395106c81fb9461290a8910af29aa0188daec29001a1181ae"
+version = "0.9.1"
+source = "git+https://github.com/pacak/bpaf.git?rev=905ab7166dd59e89bebbd3364e14b203ee57dba4#905ab7166dd59e89bebbd3364e14b203ee57dba4"
 dependencies = [
  "bpaf_derive",
  "owo-colors",
+ "supports-color",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223f3c9e7034f98c9f315d9945fcc22831b3f03d9f4c42c96a7ab6abd209a195"
+version = "0.5.1"
+source = "git+https://github.com/pacak/bpaf.git?rev=905ab7166dd59e89bebbd3364e14b203ee57dba4#905ab7166dd59e89bebbd3364e14b203ee57dba4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -382,7 +376,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -399,7 +393,7 @@ checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -422,7 +416,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -433,7 +427,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -485,7 +479,7 @@ checksum = "2a4da76b3b6116d758c7ba93f7ec6a35d2e2cf24feda76c6e38a375f4d5c59f2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -506,7 +500,28 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -527,7 +542,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -639,7 +654,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -756,21 +771,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -964,6 +976,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,9 +1024,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1024,6 +1047,12 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "log"
@@ -1094,7 +1123,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1257,7 +1286,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1410,9 +1439,6 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-dependencies = [
- "supports-color",
-]
 
 [[package]]
 name = "password-hash"
@@ -1457,7 +1483,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1552,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1610,7 +1636,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1760,7 +1786,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -1773,6 +1799,19 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustix"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1835,7 +1874,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1953,11 +1992,11 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "supports-color"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
 dependencies = [
- "atty",
+ "is-terminal",
  "is_ci",
 ]
 
@@ -1966,6 +2005,17 @@ name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1986,7 +2036,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -2040,7 +2090,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2114,7 +2164,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2125,7 +2175,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2201,7 +2251,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2378,7 +2428,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2412,7 +2462,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2481,13 +2531,37 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm 0.42.0",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -2497,10 +2571,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2509,10 +2595,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2521,16 +2619,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,7 @@ members = ["base", "db"]
 base = { package = "moonfire-base", path = "base" }
 base64 = "0.13.0"
 blake3 = "1.0.0"
-bpaf = { version = "0.7.9", features = ["autocomplete", "bright-color", "derive"]}
+bpaf = { git = "https://github.com/pacak/bpaf.git", rev = "905ab7166dd59e89bebbd3364e14b203ee57dba4", features = ["autocomplete", "bright-color", "derive"]}
 bytes = "1"
 byteorder = "1.0"
 cursive = "0.20.0"

--- a/server/src/cmds/check.rs
+++ b/server/src/cmds/check.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 /// Checks database integrity (like fsck).
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("check"))]
 pub struct Args {
     #[bpaf(external(crate::parse_db_dir))]
     db_dir: PathBuf,
@@ -20,27 +20,20 @@ pub struct Args {
     compare_lens: bool,
 
     /// Trashes sample files without matching recording rows in the database.
-    /// This addresses `Missing ... row` errors.
-    ///
-    /// The ids are added to the `garbage` table to indicate the files need to
-    /// be deleted. Garbage is collected on normal startup.
+    /// This addresses `Missing ... row` errors. The ids are added to the
+    /// `garbage` table to indicate the files need to be deleted. Garbage is
+    /// collected on normal startup.
     trash_orphan_sample_files: bool,
 
     /// Deletes recording rows in the database without matching sample files.
-    ///
     /// This addresses `Recording ... missing file` errors.
     delete_orphan_rows: bool,
 
     /// Trashes recordings when their database rows appear corrupt.
-    /// This addresses "bad video_index" errors.
-    ///
-    /// The ids are added to the `garbage` table to indicate their files need to
-    /// be deleted. Garbage is collected on normal startup.
+    /// This addresses "bad video_index" errors. The ids are added to the
+    /// `garbage` table to indicate their files need to be deleted. Garbage is
+    /// collected on normal startup.
     trash_corrupt_rows: bool,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "check")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {

--- a/server/src/cmds/config/mod.rs
+++ b/server/src/cmds/config/mod.rs
@@ -21,14 +21,10 @@ mod users;
 
 /// Interactively edits configuration.
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("config"))]
 pub struct Args {
     #[bpaf(external(crate::parse_db_dir))]
     db_dir: PathBuf,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "config")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {

--- a/server/src/cmds/init.rs
+++ b/server/src/cmds/init.rs
@@ -9,14 +9,10 @@ use std::path::PathBuf;
 
 /// Initializes a database.
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("init"))]
 pub struct Args {
     #[bpaf(external(crate::parse_db_dir))]
     db_dir: PathBuf,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "init")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {

--- a/server/src/cmds/run/config.rs
+++ b/server/src/cmds/run/config.rs
@@ -14,7 +14,6 @@ use crate::json::Permissions;
 fn default_db_dir() -> PathBuf {
     crate::DEFAULT_DB_DIR.into()
 }
-
 fn default_ui_dir() -> PathBuf {
     "/usr/local/lib/moonfire-nvr/ui".into()
 }
@@ -27,7 +26,6 @@ pub struct ConfigFile {
     pub binds: Vec<BindConfig>,
 
     /// Directory holding the SQLite3 index database.
-    ///
     ///
     /// default: `/var/lib/moonfire-nvr/db`.
     #[serde(default = "default_db_dir")]

--- a/server/src/cmds/run/mod.rs
+++ b/server/src/cmds/run/mod.rs
@@ -27,23 +27,16 @@ mod config;
 
 /// Runs the server, saving recordings and allowing web access.
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("run"))]
 pub struct Args {
-    /// Path to configuration file.
-    ///
-    /// default: `/etc/moonfire-nvr.toml`. See `ref/config.md` for config file documentation.
-    #[bpaf(short, long, argument("PATH"), fallback_with(|| Ok::<_, Error>("/etc/moonfire-nvr.toml".into())))]
+    /// Path to configuration file. See `ref/config.md` for config file documentation.
+    #[bpaf(short, long, argument("PATH"), fallback("/etc/moonfire-nvr.toml".into()), debug_fallback)]
     config: PathBuf,
 
     /// Opens the database in read-only mode and disables recording.
-    ///
     /// Note this is incompatible with session authentication; consider adding
     /// a bind with `allowUnauthenticatedPermissions` to your config.
     read_only: bool,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "run")
 }
 
 // These are used in a hack to get the name of the current time zone (e.g. America/Los_Angeles).

--- a/server/src/cmds/sql.rs
+++ b/server/src/cmds/sql.rs
@@ -18,26 +18,20 @@ use std::process::Command;
 /// Note this locks the database to prevent simultaneous access with a running server. The
 /// server maintains cached state which could be invalidated otherwise.
 #[derive(Bpaf, Debug, PartialEq, Eq)]
-#[bpaf(options)]
+#[bpaf(command("sql"))]
 pub struct Args {
     #[bpaf(external(crate::parse_db_dir))]
     db_dir: PathBuf,
 
     /// Opens the database in read-only mode and locks it only for shared access.
-    ///
     /// This can be run simultaneously with `moonfire-nvr run --read-only`.
     read_only: bool,
 
     /// Arguments to pass to sqlite3.
-    ///
     /// Use the `--` separator to pass sqlite3 options, as in
     /// `moonfire-nvr sql -- -line 'select username from user'`.
     #[bpaf(positional)]
     arg: Vec<OsString>,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "sql")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {
@@ -65,11 +59,14 @@ pub fn run(args: Args) -> Result<i32, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bpaf::Parser;
 
     #[test]
     fn parse_args() {
         let args = args()
+            .to_options()
             .run_inner(bpaf::Args::from(&[
+                "sql",
                 "--db-dir",
                 "/foo/bar",
                 "--",

--- a/server/src/cmds/ts.rs
+++ b/server/src/cmds/ts.rs
@@ -7,7 +7,7 @@ use failure::Error;
 
 /// Translates between integer and human-readable timestamps.
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("config"))]
 pub struct Args {
     /// Timestamp(s) to translate.
     ///
@@ -17,10 +17,6 @@ pub struct Args {
     /// E.g.: `142913484000000`, `2020-04-26`, `2020-04-26T12:00:00:00000-07:00`.
     #[bpaf(positional("TS"), some("must specify at least one timestamp"))]
     timestamps: Vec<String>,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "ts")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {

--- a/server/src/cmds/upgrade/mod.rs
+++ b/server/src/cmds/upgrade/mod.rs
@@ -10,7 +10,7 @@ use failure::Error;
 
 /// Upgrades to the latest database schema.
 #[derive(Bpaf, Debug)]
-#[bpaf(options)]
+#[bpaf(command("upgrade"))]
 pub struct Args {
     #[bpaf(external(crate::parse_db_dir))]
     db_dir: std::path::PathBuf,
@@ -20,21 +20,14 @@ pub struct Args {
     sample_file_dir: Option<std::path::PathBuf>,
 
     /// Resets the SQLite journal_mode to the specified mode prior to
-    /// the upgrade.
-    ///
-    ///
-    /// default: `delete` (recommended). `off` is very dangerous but may be
-    /// desirable in some circumstances. See `guide/schema.md` for more
-    /// information. The journal mode will be reset to `wal` after the upgrade.
-    #[bpaf(argument("MODE"), fallback_with(|| Ok::<_, std::convert::Infallible>("delete".into())))]
+    /// the upgrade. `off` is very dangerous but may be desirable in some
+    /// circumstances. See `guide/schema.md` for more information. The journal
+    /// mode will be reset to `wal` after the upgrade.
+    #[bpaf(argument("MODE"), fallback("delete".to_owned()), debug_fallback)]
     preset_journal: String,
 
     /// Skips the normal post-upgrade vacuum operation.
     no_vacuum: bool,
-}
-
-pub fn subcommand() -> impl bpaf::Parser<Args> {
-    crate::subcommand(args(), "upgrade")
 }
 
 pub fn run(args: Args) -> Result<i32, Error> {


### PR DESCRIPTION
* take advantage of new features to default to `--help` and to print the defaults
* remove blank lines from argument help docstrings to avoid truncating the output on single `--help` arg (as opposed to `--help --help`)

I'd use the actual released 0.9.1 but it looks like it's not quite out yet. Will switch over when it is.