### PR TITLE
Make retention screen scroll on overflow

### DIFF
--- a/server/src/cmds/config/dirs.rs
+++ b/server/src/cmds/config/dirs.rs
@@ -4,6 +4,7 @@
 
 use base::strutil::{decode_size, encode_size};
 use cursive::traits::{Nameable, Resizable};
+use cursive::view::Scrollable;
 use cursive::views;
 use cursive::Cursive;
 use db::writer;
@@ -423,7 +424,7 @@ fn edit_dir_dialog(db: &Arc<db::Database>, siv: &mut Cursive, dir_id: i32) {
     siv.add_layer(
         views::Dialog::around(
             views::LinearLayout::vertical()
-                .child(list)
+                .child(list.scrollable())
                 .child(views::DummyView)
                 .child(buttons),
         )


### PR DESCRIPTION
Makes the sample retention screen scrollable on overflow if there are too many cameras, instead of cutting off rows.

![image](https://github.com/scottlamb/moonfire-nvr/assets/5225017/dcfcb1f3-c413-44b0-b3f3-ebfd5ca1f1f4)
