### PR TITLE
Fix TimeoutStartSec invalid parsing in moonfire-nvr.service Systemd config

### DIFF
--- a/guide/install.md
+++ b/guide/install.md
@@ -213,7 +213,8 @@ Environment=MOONFIRE_FORMAT=systemd
 Environment=MOONFIRE_LOG=info
 Environment=RUST_BACKTRACE=1
 Type=notify
-TimeoutStartSec=300 # large installations take a while to scan the sample file dirs
+# large installations take a while to scan the sample file dirs
+TimeoutStartSec=300
 User=moonfire-nvr
 Restart=on-failure
 CPUAccounting=true


### PR DESCRIPTION
Systemd syntax expects a comment in a single line, hence the parsing failure 
https://www.freedesktop.org/software/systemd/man/latest/systemd.syntax.html

Before;
```
[leandro@nuc ~]$ sudo systemd-analyze verify /etc/systemd/system/moonfire-nvr.service
/etc/systemd/system/moonfire-nvr.service:16: Failed to parse TimeoutStartSec= parameter, ignoring: 300 # large installations take a while to scan the sample file dirs
[leandro@nuc ~]$
```

After;
```
[leandro@nuc ~]$ sudo systemd-analyze verify /etc/systemd/system/moonfire-nvr.service
[leandro@nuc ~]$
```