### PR TITLE
[39] Implement DELETE /api/cameras/<uuid>/<stream>/view.mp4?s=X-Y to delete whole recordings

### DIFF
--- a/ref/api.md
+++ b/ref/api.md
@@ -509,7 +509,7 @@ Bugs and limitations:
 
 ### `DELETE /api/cameras/<uuid>/<stream>/view.mp4`
 
-Requires the `viewVideo` permission.
+Requires the `adminStorage` permission.
 
 Asynchronously deletes recordings.
 
@@ -957,6 +957,7 @@ A JSON object of permissions to perform various actions:
 *   `readCameraConfigs`: bool, read camera configs including credentials
 *   `updateSignals`: bool
 *   `viewVideo`: bool
+*   `adminStorage`: bool
 
 See endpoints above for more details on the contexts in which these are
 required.

--- a/ref/api.md
+++ b/ref/api.md
@@ -511,9 +511,7 @@ Bugs and limitations:
 
 Requires the `viewVideo` permission.
 
-Returns a `.mp4` file, with an etag and support for range requests. The MIME
-type will be `video/mp4`, with a `codecs` parameter as specified in
-[RFC 6381][rfc-6381].
+Asynchronously deletes recordings.
 
 Expected query parameters:
 
@@ -532,12 +530,6 @@ Example request URI to delete recording ids 1–5 from the given camera
 ```
     /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4?s=1-5
 ```
-
-Bugs and limitations:
-
-*   If the `s=` parameter references a recording id that doesn't exist when the
-    server starts processing the `/view.mp4` request, the server will return a
-    `500` with a text error message.
 
 ### `GET /api/cameras/<uuid>/<stream>/view.mp4.txt`
 

--- a/ref/api.md
+++ b/ref/api.md
@@ -513,22 +513,28 @@ Requires the `adminStorage` permission.
 
 Asynchronously deletes recordings.
 
-Expected query parameters:
+Expected request parameters:
 
 *   `s` (one or more): a string of the form `START_ID[-END_ID]`. This
     specifies *recordings* to delete. The ids to retrieve are as returned by
     the `/recordings` URL.
 
-Example request URI to delete recording id 1 from the given camera:
+Example request to delete recording id 1 from the given camera:
 
 ```
-    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4?s=1
+    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4
+    {
+      "s": "1"
+    }
 ```
 
 Example request URI to delete recording ids 1–5 from the given camera
 
 ```
-    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4?s=1-5
+    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4
+    {
+      "s": "1-5"
+    }
 ```
 
 ### `GET /api/cameras/<uuid>/<stream>/view.mp4.txt`

--- a/ref/api.md
+++ b/ref/api.md
@@ -511,12 +511,11 @@ Bugs and limitations:
 
 Requires the `adminStorage` permission.
 
-Asynchronously deletes recordings.
+Asynchronously deletes a recording.
 
 Expected request parameters:
 
-*   `s` (one or more): a string of the form `START_ID[-END_ID]`. This
-    specifies *recordings* to delete. The ids to retrieve are as returned by
+*   `runStartId` (one or more): a number as returned by
     the `/recordings` URL.
 
 Example request to delete recording id 1 from the given camera:
@@ -524,16 +523,7 @@ Example request to delete recording id 1 from the given camera:
 ```
     /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4
     {
-      "s": "1"
-    }
-```
-
-Example request URI to delete recording ids 1–5 from the given camera
-
-```
-    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4
-    {
-      "s": "1-5"
+      "runStartId": 1
     }
 ```
 

--- a/ref/api.md
+++ b/ref/api.md
@@ -11,6 +11,7 @@ Status: **current**.
     * [`GET /api/cameras/<uuid>/`](#get-apicamerasuuid)
     * [`GET /api/cameras/<uuid>/<stream>/recordings`](#get-apicamerasuuidstreamrecordings)
     * [`GET /api/cameras/<uuid>/<stream>/view.mp4`](#get-apicamerasuuidstreamviewmp4)
+    * [`DELETE /api/cameras/<uuid>/<stream>/view.mp4`](#delete-apicamerasuuidstreamviewmp4)
     * [`GET /api/cameras/<uuid>/<stream>/view.mp4.txt`](#get-apicamerasuuidstreamviewmp4txt)
     * [`GET /api/cameras/<uuid>/<stream>/view.m4s`](#get-apicamerasuuidstreamviewm4s)
     * [`GET /api/cameras/<uuid>/<stream>/view.m4s.txt`](#get-apicamerasuuidstreamviewm4stxt)
@@ -505,6 +506,38 @@ Bugs and limitations:
     recording 2/16672 after recording 2/16671 with trailing zero`. See also
     `hasTrailingZero` above, and
     [#178](https://github.com/scottlamb/moonfire-nvr/issues/178).
+
+### `DELETE /api/cameras/<uuid>/<stream>/view.mp4`
+
+Requires the `viewVideo` permission.
+
+Returns a `.mp4` file, with an etag and support for range requests. The MIME
+type will be `video/mp4`, with a `codecs` parameter as specified in
+[RFC 6381][rfc-6381].
+
+Expected query parameters:
+
+*   `s` (one or more): a string of the form `START_ID[-END_ID]`. This
+    specifies *recordings* to delete. The ids to retrieve are as returned by
+    the `/recordings` URL.
+
+Example request URI to delete recording id 1 from the given camera:
+
+```
+    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4?s=1
+```
+
+Example request URI to delete recording ids 1–5 from the given camera
+
+```
+    /api/cameras/fd20f7a2-9d69-4cb3-94ed-d51a20c3edfe/main/view.mp4?s=1-5
+```
+
+Bugs and limitations:
+
+*   If the `s=` parameter references a recording id that doesn't exist when the
+    server starts processing the `/view.mp4` request, the server will return a
+    `500` with a text error message.
 
 ### `GET /api/cameras/<uuid>/<stream>/view.mp4.txt`
 

--- a/server/db/db.rs
+++ b/server/db/db.rs
@@ -1543,11 +1543,11 @@ impl LockedDatabase {
             Some(d) => d,
         };
 
-        let composite_ids = CompositeId::new(stream_id, recording_ids.start)..CompositeId::new(stream_id, recording_ids.end);
-
         {
             let tx = self.conn.transaction()?;
-            raw::delete_recordings(&tx, dir_id, composite_ids)?;
+            for recording_id in recording_ids {
+               raw::delete_recordings(&tx, dir_id, CompositeId::new(stream_id, recording_id)..CompositeId::new(stream_id, recording_id+1))?;
+            }
             let new_garbage_needs_unlink = raw::list_garbage(&tx, dir_id)?;
             tx.commit()?;
             dir.garbage_needs_unlink = new_garbage_needs_unlink;

--- a/server/db/db.rs
+++ b/server/db/db.rs
@@ -1523,7 +1523,7 @@ impl LockedDatabase {
         }
     }
 
-    /// Transfer given recordings to garbage and refresh in-memory map
+    /// Transfers given recordings to garbage and refresh in-memory map
     /// of files to garbage collect.
     pub fn delete_recordings(
         &mut self,

--- a/server/db/db.rs
+++ b/server/db/db.rs
@@ -1543,11 +1543,11 @@ impl LockedDatabase {
             Some(d) => d,
         };
 
+        let composite_ids = CompositeId::new(stream_id, recording_ids.start)..CompositeId::new(stream_id, recording_ids.end);
+
         {
             let tx = self.conn.transaction()?;
-            for recording_id in recording_ids {
-               raw::delete_recordings(&tx, dir_id, CompositeId::new(stream_id, recording_id)..CompositeId::new(stream_id, recording_id+1))?;
-            }
+            raw::delete_recordings(&tx, dir_id, composite_ids)?;
             let new_garbage_needs_unlink = raw::list_garbage(&tx, dir_id)?;
             tx.commit()?;
             dir.garbage_needs_unlink = new_garbage_needs_unlink;

--- a/server/db/proto/schema.proto
+++ b/server/db/proto/schema.proto
@@ -68,4 +68,5 @@ message Permissions {
   bool read_camera_configs = 2;
   bool update_signals = 3;
   bool admin_users = 4;
+  bool admin_storage = 5;
 }

--- a/server/src/json.rs
+++ b/server/src/json.rs
@@ -525,6 +525,15 @@ pub struct ToplevelUser {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
+pub struct DeleteRecordings<'a> {
+    #[serde(borrow)]
+    pub csrf: Option<&'a str>,
+    pub s: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PutUsers<'a> {
     #[serde(borrow)]
     pub csrf: Option<&'a str>,

--- a/server/src/json.rs
+++ b/server/src/json.rs
@@ -608,6 +608,9 @@ pub struct Permissions {
 
     #[serde(default)]
     pub admin_users: bool,
+
+    #[serde(default)]
+    pub admin_storage: bool,
 }
 
 impl From<Permissions> for db::schema::Permissions {
@@ -617,6 +620,7 @@ impl From<Permissions> for db::schema::Permissions {
             read_camera_configs: p.read_camera_configs,
             update_signals: p.update_signals,
             admin_users: p.admin_users,
+            admin_storage: p.admin_storage,
             special_fields: Default::default(),
         }
     }
@@ -629,6 +633,7 @@ impl From<db::schema::Permissions> for Permissions {
             read_camera_configs: p.read_camera_configs,
             update_signals: p.update_signals,
             admin_users: p.admin_users,
+            admin_storage: p.admin_storage,
         }
     }
 }

--- a/server/src/json.rs
+++ b/server/src/json.rs
@@ -528,7 +528,7 @@ pub struct ToplevelUser {
 pub struct DeleteRecordings<'a> {
     #[serde(borrow)]
     pub csrf: Option<&'a str>,
-    pub s: &'a str,
+    pub run_start_id: i32,
 }
 
 #[derive(Debug, Deserialize)]

--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -628,6 +628,7 @@ impl Service {
                     read_camera_configs: true,
                     update_signals: true,
                     admin_users: true,
+                    admin_storage: true,
                     ..Default::default()
                 },
                 user: None,

--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -28,7 +28,7 @@ use core::str::FromStr;
 use db::dir::SampleFileDir;
 use db::{auth, recording};
 use http::header::{self, HeaderValue};
-use http::{status::StatusCode, Request, Response};
+use http::{status::StatusCode, Request, Response, Method};
 use hyper::body::Bytes;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -254,7 +254,10 @@ impl Service {
             ),
             Path::StreamViewMp4(uuid, type_, debug) => (
                 CacheControl::PrivateStatic,
-                self.stream_view_mp4(&req, caller, uuid, type_, mp4::Type::Normal, debug)?,
+                match req.method() {
+                  &Method::DELETE => self.delete_view_mp4(&req, caller, uuid, type_)?,
+                  _ => self.stream_view_mp4(&req, caller, uuid, type_, mp4::Type::Normal, debug)?,
+                },
             ),
             Path::StreamViewMp4Segment(uuid, type_, debug) => (
                 CacheControl::PrivateStatic,

--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -255,7 +255,7 @@ impl Service {
             Path::StreamViewMp4(uuid, type_, debug) => (
                 CacheControl::PrivateStatic,
                 match req.method() {
-                  &Method::DELETE => self.delete_view_mp4(&req, caller, uuid, type_)?,
+                  &Method::DELETE => self.delete_view_mp4(req, caller, uuid, type_).await?,
                   _ => self.stream_view_mp4(&req, caller, uuid, type_, mp4::Type::Normal, debug)?,
                 },
             ),

--- a/server/src/web/view.rs
+++ b/server/src/web/view.rs
@@ -236,12 +236,9 @@ impl Service {
                 .ok_or_else(|| err!(NotFound, msg("no such stream {uuid}/{stream_type}")))?;
         };
 
-        let s = Segments::from_str(r.s).map_err(|()| {
-            err!(InvalidArgument, msg("invalid s parameter: {}", r.s))
-        })?;
-        trace!("delete_view_mp4: deleting s={:?}", s);
+        trace!("delete_view_mp4: deleting s={:?}", r.run_start_id);
         let mut db = self.db.lock();
-        db.delete_recordings(stream_id, s.ids)?;
+        db.delete_recording(stream_id, r.run_start_id)?;
 
         Ok(plain_response(StatusCode::OK, format!("OK")))
     }

--- a/server/src/web/view.rs
+++ b/server/src/web/view.rs
@@ -216,8 +216,8 @@ impl Service {
         uuid: Uuid,
         stream_type: db::StreamType,
     ) -> ResponseResult {
-        if !caller.permissions.view_video {
-            bail!(PermissionDenied, msg("view_video required"));
+        if !caller.permissions.admin_storage {
+            bail!(PermissionDenied, msg("admin_storage required"));
         }
         let stream_id;
 


### PR DESCRIPTION
https://github.com/scottlamb/moonfire-nvr/issues/39

Continuous garbage collection only seems to start from `server/db/writer.rs#delete_oldest_recordings`. I don't want to delete "enough old recordings to be within disk restrictions" without pruning the API deleted recordings first. I made the `LockedDatabase::delete_recordings()` also re-initialize the `SampleFileDir`s' `garbage_needs_unlink` collections.

While `DELETE /api/cameras/.../.../view.mp4` is a little strange, given `GET view.mp4` does a live transformation to MP4 to justify its name, I do like the DELETE endpoint is guessable from the GET endpoint.