### PR TITLE
ui/live view: add 2x3 and 3x2 layouts

### DIFF
--- a/ui/src/Live/Multiview.tsx
+++ b/ui/src/Live/Multiview.tsx
@@ -24,6 +24,8 @@ const LAYOUTS: Layout[] = [
   { className: "dual", cameras: 2, name: "2" },
   { className: "main-plus-five", cameras: 6, name: "Main + 5" },
   { className: "two-by-two", cameras: 4, name: "2x2" },
+  { className: "two-by-three", cameras: 6, name: "2x3" },
+  { className: "three-by-two", cameras: 6, name: "3x2" },
   { className: "three-by-three", cameras: 9, name: "3x3" },
 ];
 const MAX_CAMERAS = 9;
@@ -252,6 +254,14 @@ const Multiview = (props: MultiviewProps) => {
             },
             "&.two-by-two": {
               gridTemplateColumns: "repeat(2, calc(100% / 2))",
+              gridTemplateRows: "repeat(2, calc(100% / 2))",
+            },
+            "&.two-by-three": {
+              gridTemplateColumns: "repeat(2, calc(100% / 2))",
+              gridTemplateRows: "repeat(3, calc(100% / 3))",
+            },
+            "&.three-by-two": {
+              gridTemplateColumns: "repeat(3, calc(100% / 3))",
               gridTemplateRows: "repeat(2, calc(100% / 2))",
             },
             "&.main-plus-five, &.three-by-three": {


### PR DESCRIPTION
Hi,
I know you have bigger plans for this (#115), but in the mean time I hope it's OK to put some new layouts which I am missing a lot from the bluecherry nvr:
- The 2x3 is my main layout for my 5-6 cams on a 5:4 monitor
- 3x2 is better for 16:9